### PR TITLE
16 portainer

### DIFF
--- a/infrastructure/hopps-app/docker-compose.yaml
+++ b/infrastructure/hopps-app/docker-compose.yaml
@@ -1,0 +1,6 @@
+services:
+  hopps-backend:
+    image: ghcr.io/hopps-app/hopps/vereine:backend-ci-cd
+    container_name: hopps-backend
+    ports:
+      - 8080:8080

--- a/infrastructure/portainer/docker-compose.yaml
+++ b/infrastructure/portainer/docker-compose.yaml
@@ -1,0 +1,16 @@
+version: '3'
+
+services:
+  portainer:
+    image: portainer/portainer-ce:latest
+    container_name: portainer
+    restart: always
+    ports:
+      - 8000:8000
+      - 9443:9443
+    volumes:
+      - /portainer_data:/data
+      - /var/run/docker.sock:/var/run/docker.sock
+
+volumes:
+    - portainer_data


### PR DESCRIPTION
Closes #16 

* Portainer unter [https://128.140.15.118:9443](https://128.140.15.118:9443) abrufbar
* Backend Service Verein ist abrufbar unter [http://128.140.15.118:8080](http://128.140.15.118:8080): `Resource not found` 
* Vereins backend ist deployed mittels Portainer und dem docker-compose.yaml aus diesem Branch
* OAuth Anmeldung mittels GitHub ist möglich
* Die Arbeitschritte sind im [Wiki Dokumentiert](https://github.com/hopps-app/hopps/wiki/Infrastruktur)
* Leider ist 

Zukünftige Improvements:
* Liste von erlaubten GitHub Accounts, verbunden mit Portainer (falls möglich)
* Reverse Proxy 
 