### PR TITLE
🔧 Update jacoco/sonar for az-documentation-ai

### DIFF
--- a/.github/workflows/backend-sonarqube-analysis.yml
+++ b/.github/workflows/backend-sonarqube-analysis.yml
@@ -5,13 +5,12 @@ on:
     paths:
       - backend/**
       - .github/workflows/backend-sonarqube-analysis.yml
-    branches: [ 'main' ]
+    branches: [ "main" ]
   pull_request:
     paths:
       - backend/**
       - .github/workflows/backend-sonarqube-analysis.yml
-    types: [opened, reopened, synchronize]
-
+    types: [ opened, reopened, synchronize ]
 
 jobs:
   build-and-analyse:
@@ -21,12 +20,12 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: "21"
+          distribution: "temurin"
           cache: maven
 
       - name: mvn package
-        run: mvn -B package --file backend/pom.xml
+        run: mvn -B verify --file backend/pom.xml
 
       - name: Cache SonarQube packages
         uses: actions/cache@v4
@@ -35,12 +34,22 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
-      - name: SonarQube Scan
+      - name: SonarQube Scan "AZ Document AI"
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
-            --file backend/pom.xml \
+          mvn -B sonar:sonar \
+            --file backend/app.hopps.az-document-ai/pom.xml \
             -Dsonar.host.url=https://sonarcloud.io \
             -Dsonar.organization=hopps-app \
-            -Dsonar.projectKey=hopps-app_hopps
+            -Dsonar.projectKey=hopps-app_hopps-document-ai
+
+      - name: SonarQube Scan "Vereine"
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          mvn -B sonar:sonar \
+            --file backend/app.hopps.org/pom.xml \
+            -Dsonar.host.url=https://sonarcloud.io \
+            -Dsonar.organization=hopps-app \
+            -Dsonar.projectKey=hopps-app_hopps-vereine

--- a/backend/app.hopps.az-document-ai/pom.xml
+++ b/backend/app.hopps.az-document-ai/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -25,6 +26,9 @@
         <quarkus.platform.version>3.15.1</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.1</surefire-plugin.version>
+        <sonar.coverage.jacoco.xmlReportPaths>
+            ${project.build.directory}/jacoco-report/jacoco.xml
+        </sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <dependencyManagement>
@@ -149,7 +153,9 @@
                 </executions>
                 <configuration>
                     <systemPropertyVariables>
-                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                        <native.image.path>
+                            ${project.build.directory}/${project.build.finalName}-runner
+                        </native.image.path>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <!--suppress UnresolvedMavenProperty -->
                         <maven.home>${maven.home}</maven.home>

--- a/backend/app.hopps.org/pom.xml
+++ b/backend/app.hopps.org/pom.xml
@@ -26,6 +26,9 @@
         <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.1</surefire-plugin.version>
+        <sonar.coverage.jacoco.xmlReportPaths>
+            ${project.build.directory}/jacoco-report/jacoco.xml
+        </sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <dependencyManagement>
@@ -142,6 +145,11 @@
             <artifactId>quarkus-junit5-mockito</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jacoco</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -192,7 +200,8 @@
                         </goals>
                         <configuration>
                             <systemPropertyVariables>
-                                <native.image.path>${project.build.directory}/${project.build.finalName}-runner
+                                <native.image.path>
+                                    ${project.build.directory}/${project.build.finalName}-runner
                                 </native.image.path>
                                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                                 <!--suppress UnresolvedMavenProperty -->
@@ -201,11 +210,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.sonarsource.scanner.maven</groupId>
-                <artifactId>sonar-maven-plugin</artifactId>
-                <version>4.0.0.4121</version>
             </plugin>
         </plugins>
     </build>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -15,7 +15,8 @@
     </properties>
 
     <name>Hopps</name>
-    <description>Hopps will be a cloud-based open-source accounting software with AI, so that non-profits have more time for
+    <description>
+        Hopps will be a cloud-based open-source accounting software with AI, so that non-profits have more time for
         their essential goals and offerings, and frustrating situations with accounting are a thing of the past.
     </description>
 
@@ -51,6 +52,11 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>4.0.0.4121</version>
+            </plugin>
+            <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
                 <version>2.23.0</version>
@@ -66,7 +72,6 @@
                     <configFile>${project.basedir}/../formatter/java.xml</configFile>
                 </configuration>
             </plugin>
-
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
@@ -74,6 +79,24 @@
                 <configuration>
                     <projectType>application</projectType>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <exclClassLoaders>*QuarkusClassLoader</exclClassLoaders>
+                            <destFile>${project.build.directory}/jacoco-quarkus.exec</destFile>
+                            <append>true</append>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Dies sollte für das backend `az-documentation-ai` das sonar richtig publishen.  

Wenn wir das für beide backends haben wollen, müssten wir dies in die `pom.xml` im `backend` Order einbinden.

Sorry für formatting, ich benutze aktuell VSCode 😞 