### PR TITLE
🔧 Update actions

### DIFF
--- a/.github/workflows/backend-sonarqube-analysis.yml
+++ b/.github/workflows/backend-sonarqube-analysis.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   build-and-analyse:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - backend/**
       - .github/workflows/backend.yml
-    branches: [ '**' ]
+    branches: [ "**" ]
     tags: [ 'org-*.*.*' ]
 
 env:

--- a/.github/workflows/dependency-track-analysis.yml
+++ b/.github/workflows/dependency-track-analysis.yml
@@ -5,16 +5,17 @@ on:
     paths:
       - backend/**
       - .github/workflows/dependency-track-analysis.yml
-    branches: ["main"]
+    branches: [ "main" ]
   pull_request:
     paths:
       - backend/**
       - .github/workflows/dependency-track-analysis.yml
-    types: [opened, reopened, synchronize]
+    types: [ opened, reopened, synchronize ]
 
 jobs:
   upload-bom:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       # Checkout the code
       - uses: actions/checkout@v4

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -2,19 +2,22 @@ name: CI/CD Pipeline for frontend
 
 on:
   push:
-    branches:
-      - main
-      - feature/**
+    paths:
+      - frontend/**
+      - .github/workflows/frontend.yml
+    branches: [ "**" ]
     tags:
       - 'spa-*.*.*'
   pull_request:
+    paths:
+      - frontend/**
+      - .github/workflows/frontend.yml
     branches:
       - main
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Updates the github-actions so the dependabot only tries to build the projects and not publishes something to dependencytrack or sonarqube.

Why? [See here](https://github.com/dependabot/dependabot-core/issues/3253)