### PR TITLE
🔧 Disable pushing to external sources for dependabot MRs

### DIFF
--- a/.github/workflows/backend-sonarqube-analysis.yml
+++ b/.github/workflows/backend-sonarqube-analysis.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build-and-analyse:
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ !startsWith(github.ref, 'refs/heads/dependabot') }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -73,5 +73,5 @@ jobs:
           context: backend/${{ matrix.service.directory }}
           file: backend/${{ matrix.service.directory }}/src/main/docker/Dockerfile.jvm
           # don't push dependabot branches
-          push: ${{ !startsWith(github.ref, 'refs/heads/dependabot/maven/backend') }}
+          push: ${{ !startsWith(github.ref, 'refs/heads/dependabot') }}
           tags: ${{ steps.meta.outputs.tags }} # tags from the docker/metadata-action

--- a/.github/workflows/dependency-track-analysis.yml
+++ b/.github/workflows/dependency-track-analysis.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   upload-bom:
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ !startsWith(github.ref, 'refs/heads/dependabot') }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/frontend-dependency-track.yaml
+++ b/.github/workflows/frontend-dependency-track.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build:
-    if: ${{ !startsWith(github.ref, 'refs/heads/dependabot/maven/backend') }}
+    if: ${{ !startsWith(github.ref, 'refs/heads/dependabot') }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -78,5 +78,5 @@ jobs:
         with:
           context: ${{ matrix.baseDirectory }}
           file: ${{ matrix.baseDirectory }}/docker/Dockerfile
-          push: ${{ !startsWith(github.ref, 'refs/heads/dependabot/maven/backend') }}
+          push: ${{ !startsWith(github.ref, 'refs/heads/dependabot') }}
           tags: ghcr.io/${{ github.repository }}/frontend:${{ env.VERSION }}


### PR DESCRIPTION
I messed up with the ifs in the github actions. This should fix dependabot MRs fails. It will now never push docker images/sonar/sbom.