### PR TITLE
🔧 Update keycloak dev-service

### DIFF
--- a/backend/app.hopps.az-document-ai/src/main/resources/application.properties
+++ b/backend/app.hopps.az-document-ai/src/main/resources/application.properties
@@ -1,7 +1,8 @@
 # General
 %dev.quarkus.http.port=8100
-#
+########################################
 # Kafka
+########################################
 %dev.quarkus.kafka.devservices.port=32782
 #
 ## Incoming
@@ -20,7 +21,9 @@ mp.messaging.outgoing.receipts-out.connector=smallrye-kafka
 mp.messaging.outgoing.receipts-out.topic=app.hopps.documents.receipt-data
 mp.messaging.outgoing.receipts-out.cloud-events=true
 #
+########################################
 # Azure
+########################################
 app.hopps.az-document-ai.azure.endpoint=${HOPPS_AZURE_DOCUMENT_AI_ENDPOINT}
 app.hopps.az-document-ai.azure.key=${HOPPS_AZURE_DOCUMENT_AI_KEY}
 %test.app.hopps.az-document-ai.azure.endpoint=${HOPPS_AZURE_DOCUMENT_AI_ENDPOINT:http://azure-endpoint.test/something}

--- a/backend/app.hopps.fin/src/main/resources/application.properties
+++ b/backend/app.hopps.fin/src/main/resources/application.properties
@@ -1,22 +1,32 @@
 # Quarkus
 quarkus.banner.path=banner.txt
-#
+########################################
 # Hibernate
+########################################
+#
+########################################
 # Keycloak/auth
+########################################
 app.hopps.vereine.auth.default-role=Owner
 app.hopps.vereine.auth.realm-name=quarkus
+# override in prod
+quarkus.keycloak.admin-client.server-url=http://localhost:8554
 quarkus.keycloak.admin-client.enabled=true
-%dev.quarkus.keycloak.admin-client.server-url=http://localhost:8554
-%test.quarkus.keycloak.admin-client.server-url=http://localhost:8554
-%test.quarkus.keycloak.devservices.port=8554
-quarkus.keycloak.devservices.realm-name=quarkus
 quarkus.keycloak.admin-client.realm=master
 quarkus.keycloak.admin-client.client-id=admin-cli
 quarkus.keycloak.admin-client.username=admin
 quarkus.keycloak.admin-client.password=admin
 quarkus.keycloak.admin-client.grant-type=PASSWORD
+
 %dev.quarkus.security.auth.enabled-in-dev-mode=false
-#
-# OpenFGA auth
+###
+# devservice
+###
+%prod.quarkus.keycloak.devservices.enabled=false
+quarkus.keycloak.devservices.port=8554
+quarkus.keycloak.devservices.realm-name=quarkus
+######################################
+# OpenFGA
+######################################
 %prod.quarkus.openfga.url=${HOPPS_OPENFGA_URL}
 quarkus.openfga.store=${HOPPS_OPENFGA_STORE:my-app-authz}

--- a/backend/app.hopps.org/src/main/resources/application.properties
+++ b/backend/app.hopps.org/src/main/resources/application.properties
@@ -1,21 +1,31 @@
 # Quarkus
 quarkus.banner.path=banner.txt
+########################################
+# Hibernate
+########################################
 #
-# Hibernatec
+########################################
 # Keycloak/auth
+########################################
 app.hopps.vereine.auth.default-role=Owner
 app.hopps.vereine.auth.realm-name=quarkus
+# override in prod
+quarkus.keycloak.admin-client.server-url=http://localhost:8554
 quarkus.keycloak.admin-client.enabled=true
-%dev.quarkus.keycloak.admin-client.server-url=http://localhost:8554
-%test.quarkus.keycloak.admin-client.server-url=http://localhost:8554
-%test.quarkus.keycloak.devservices.port=8554
-quarkus.keycloak.devservices.realm-name=quarkus
 quarkus.keycloak.admin-client.realm=master
 quarkus.keycloak.admin-client.client-id=admin-cli
 quarkus.keycloak.admin-client.username=admin
 quarkus.keycloak.admin-client.password=admin
 quarkus.keycloak.admin-client.grant-type=PASSWORD
 %dev.quarkus.security.auth.enabled-in-dev-mode=false
-# OpenFGA auth
+###
+# devservice
+###
+%prod.quarkus.keycloak.devservices.enabled=false
+quarkus.keycloak.devservices.port=8554
+quarkus.keycloak.devservices.realm-name=quarkus
+########################################
+# OpenFGA
+########################################
 %prod.quarkus.openfga.url=${HOPPS_OPENFGA_URL}
 quarkus.openfga.store=${HOPPS_OPENFGA_STORE:my-app-authz}


### PR DESCRIPTION
Started org with `mvn quarkus:dev`:
![grafik](https://github.com/user-attachments/assets/10bc3687-b1a1-44dd-ac0b-ded404080cbc)


- Dev-Service port is set for dev and test now
- Disable explicitly the keycloak dev-service for prod (not needed but to be clear)