### PR TITLE
📈 (#180): Add Micrometer metrics to all services

### DIFF
--- a/backend/app.hopps.az-document-ai/pom.xml
+++ b/backend/app.hopps.az-document-ai/pom.xml
@@ -69,6 +69,14 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-health</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
         <!-- third party -->
         <dependency>
             <groupId>com.azure</groupId>

--- a/backend/app.hopps.fin/pom.xml
+++ b/backend/app.hopps.fin/pom.xml
@@ -100,6 +100,14 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-keycloak-authorization</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
 
         <!-- openfga -->
         <dependency>

--- a/backend/app.hopps.org/pom.xml
+++ b/backend/app.hopps.org/pom.xml
@@ -108,6 +108,14 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-keycloak-authorization</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
 
         <!-- kogito -->
         <dependency>


### PR DESCRIPTION
* Momentan noch nicht gegen das Management-Interface (https://quarkus.io/guides/management-interface-reference) 
* Keine eigenen Metriken, nur die aus dem Standard