### PR TITLE
🐛 (org): Throw proper error when user has no organisation

### DIFF
--- a/backend/app.hopps.org/src/main/java/app/hopps/org/rest/OrganizationResource.java
+++ b/backend/app.hopps.org/src/main/java/app/hopps/org/rest/OrganizationResource.java
@@ -83,7 +83,7 @@ public class OrganizationResource {
         String userName = securityContext.getUserPrincipal().getName();
         Member me = memberRepository.findByEmail(userName);
         if (me == null) {
-            throw new NotFoundException("Organization of User not found");
+            throw new NotFoundException("User not found in database");
         }
 
         Collection<Organization> orgs = me.getOrganizations();
@@ -92,7 +92,9 @@ public class OrganizationResource {
                     "More than one organization is currently not implemented. User:  " + userName);
         }
 
-        return orgs.stream().findFirst().orElseThrow();
+        return orgs.stream()
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException("Organization of user not found"));
     }
 
     @GET

--- a/backend/app.hopps.org/src/main/java/app/hopps/org/rest/OrganizationResource.java
+++ b/backend/app.hopps.org/src/main/java/app/hopps/org/rest/OrganizationResource.java
@@ -83,7 +83,9 @@ public class OrganizationResource {
         String userName = securityContext.getUserPrincipal().getName();
         Member me = memberRepository.findByEmail(userName);
         if (me == null) {
-            throw new NotFoundException("User not found in database");
+            throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND)
+                    .entity("User not found in database")
+                    .build());
         }
 
         Collection<Organization> orgs = me.getOrganizations();
@@ -94,7 +96,9 @@ public class OrganizationResource {
 
         return orgs.stream()
                 .findFirst()
-                .orElseThrow(() -> new NotFoundException("Organization of user not found"));
+                .orElseThrow(() -> new WebApplicationException(Response.status(Response.Status.NOT_FOUND)
+                    .entity("Organization of user not found in database")
+                    .build()));
     }
 
     @GET


### PR DESCRIPTION
Bugfix; wenn ein Nutzer ohne Organisation den my organisation endpoint aufruft sollte ein 404 zurückkommen, anstatt eines internal server errors.

@manuelhummler 