### PR TITLE
🐛 (fin): Fix baseline migration messing with our migrations.

### DIFF
--- a/backend/app.hopps.fin/src/main/resources/application.properties
+++ b/backend/app.hopps.fin/src/main/resources/application.properties
@@ -24,6 +24,7 @@ quarkus.http.auth.permission.management.policy=permit
 ########################################
 quarkus.flyway.migrate-at-start=true
 quarkus.flyway.baseline-on-migrate=true
+quarkus.flyway.baseline-version=0.0.1
 %dev,test.quarkus.flyway.clean-at-start=true
 %dev.quarkus.flyway.locations=db/migration,db/testdata
 #

--- a/kubernetes/hopps/overlays/dev/helm-release.yaml
+++ b/kubernetes/hopps/overlays/dev/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
   values:
     azDocumentAi:
       image:
-        tag: 530
+        tag: 531
       envFrom:
         - secretRef:
             name: az-document-ai
@@ -24,7 +24,7 @@ spec:
           value: hopps-kafka:9092
     org:
       image:
-        tag: 530
+        tag: 531
       envFrom:
         - secretRef:
             name: org
@@ -69,7 +69,7 @@ spec:
       enabled: false
     fin:
       image:
-        tag: 530
+        tag: 531
       envFrom:
         - secretRef:
             name: fin
@@ -123,7 +123,7 @@ spec:
 
     finNarrator:
       image:
-        tag: 370
+        tag: 531
       envVars:
         - name: quarkus.langchain4j.openai.api-key
           valueFrom:


### PR DESCRIPTION
Changes the fin service's baseline migration version to stop it messing with our version (default for baseline seems to be V1, ours is V1.0.0, so our migration was mistakenly skipped). This pulls up the version of most services to 531, which doesn't exist right now, but should be the correct one once this PR gets merged.