### PR TITLE
🩺 (fin-narrator): Add fin-narrator healthcheck for deployment

### DIFF
--- a/backend/app.hopps.fin-narrator/pom.xml
+++ b/backend/app.hopps.fin-narrator/pom.xml
@@ -59,6 +59,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
The deployment of fin-narrator currently fails due to missing healthchecks, this adds those.

TODO:
- [ ] test this on the kubernetes