### PR TITLE
Bug: Keycloak Input Fields Error 

### DIFF
--- a/frontend/keycloak-theme/src/login/main.css
+++ b/frontend/keycloak-theme/src/login/main.css
@@ -98,6 +98,12 @@ input[type="password"] {
     outline: none;
     font-size: 14px;
 }
+.pf-c-form-control[aria-invalid="true"] {
+    background-image: none !important;
+    background-color: #ffe6e6;
+    border-color: #aa0000 !important; 
+    box-shadow: none !important;
+  }
 .pf-c-input-group {
     position: relative;
 }


### PR DESCRIPTION
The login form input fields display a repeating red exclamation mark background when an error occurs. This makes the input text unreadable and breaks the intended visual styling.