### PR TITLE
🔧 use bruno's new way of inserting oauth2 bearer's into requests

### DIFF
--- a/backend/api/collection.bru
+++ b/backend/api/collection.bru
@@ -1,7 +1,3 @@
-headers {
-  Authorization: Bearer {{access_token_set_by_collection_script}}
-}
-
 auth {
   mode: oauth2
 }
@@ -11,15 +7,16 @@ auth:oauth2 {
   callback_url: {{keycloak_redirect_url}}
   authorization_url: {{keycloak_url}}/realms/{{keycloak_realm}}/protocol/openid-connect/auth
   access_token_url: {{keycloak_url}}/realms/{{keycloak_realm}}/protocol/openid-connect/token
+  refresh_token_url: 
   client_id: {{keycloak_client}}
   client_secret: 
   scope: 
   state: 
   pkce: true
-}
-
-script:post-response {
-  if(req.getAuthMode() == 'oauth2' && res.body.access_token) {
-      bru.setVar('access_token_set_by_collection_script', res.body.access_token);
-  }
+  credentials_placement: body
+  credentials_id: credentials
+  token_placement: header
+  token_header_prefix: 
+  auto_fetch_token: true
+  auto_refresh_token: false
 }

--- a/backend/api/org API/Organization Resource/Create a new organization.bru
+++ b/backend/api/org API/Organization Resource/Create a new organization.bru
@@ -7,29 +7,29 @@ meta {
 post {
   url: {{baseUrl}}/organization
   body: json
-  auth: none
+  auth: inherit
 }
 
 body:json {
   {
     "owner": {
-      "email": "",
-      "firstName": "",
-      "lastName": ""
+      "email": "test@test.com",
+      "firstName": "emilia",
+      "lastName": "jaser"
     },
-    "newPassword": "",
+    "newPassword": "password",
     "organization": {
-      "name": "",
-      "slug": "",
-      "type": "",
-      "website": "",
+      "name": "string",
+      "slug": "string",
+      "type": "EINGETRAGENER_VEREIN",
+      "website": "https://byte-sized.fyi/",
       "profilePicture": "",
       "address": {
-        "street": "",
-        "number": "",
-        "city": "",
-        "plz": "",
-        "additionalLine": ""
+        "street": "Raketenstraße",
+        "number": "42a",
+        "city": "Raketenstadt",
+        "plz": "4242",
+        "additionalLine": "Hinterhaus"
       }
     }
   }

--- a/backend/api/org API/folder.bru
+++ b/backend/api/org API/folder.bru
@@ -1,0 +1,7 @@
+meta {
+  name: org API
+}
+
+vars:pre-request {
+  baseUrl: {{org_baseUrl}}
+}


### PR DESCRIPTION
We no longer need a """hacky""" script to insert the bearer acquired from keycloak into our requests. Bruno's oauth2 client can now do this, an update might be required for devs. On individual requests, you can either select "No auth" to not authenticate your request, or "inherit" to use the oauth2 authentication defined for the entire collection.