### PR TITLE
Fix typos, invoice tag type, and expand theme service tests

### DIFF
--- a/backend/app.hopps.fin-narrator/src/main/java/app/hopps/fin/narrator/TaggingResource.java
+++ b/backend/app.hopps.fin-narrator/src/main/java/app/hopps/fin/narrator/TaggingResource.java
@@ -43,7 +43,7 @@ public class TaggingResource {
     @Operation(summary = "Generates a list of tags for this invoice")
     @APIResponse(responseCode = "200", description = "Generated tags", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(contentSchema = String[].class), example = "[\"food\", \"pizza\"]"))
     public List<String> tagInvoice(JsonObject jsonData) throws JsonProcessingException {
-        return tagDocument("invoicoe", jsonData);
+        return tagDocument("invoice", jsonData);
     }
 
     @POST

--- a/frontend/api-client/README.md
+++ b/frontend/api-client/README.md
@@ -115,7 +115,7 @@ npm run build
 To publish the package:
 
 ```bash
-npm run publish
+npm run release
 ```
 
 ## License

--- a/frontend/spa/README.md
+++ b/frontend/spa/README.md
@@ -5,7 +5,7 @@ It is written in [React](https://react.dev/).
 
 ## Project setup
 
-### Prequesites
+### Prerequisites
 - Install [NodeJs v22.15.0+](https://nodejs.org/en) (if you want to handle several Node installations locally for different projects check [nvm](https://github.com/nvm-sh/nvm))
 
 ### Optional

--- a/frontend/spa/src/services/__tests__/ThemeService.test.ts
+++ b/frontend/spa/src/services/__tests__/ThemeService.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ThemeService, Themes } from '../ThemeService';
 
@@ -34,5 +34,26 @@ describe('ThemeService', () => {
         service.setDarkMode(false);
         expect(service.getTheme()).toBe(Themes.light);
         expect(document.documentElement.classList.contains(Themes.dark)).toBe(false);
+    });
+
+    it('should enable auto mode by clearing preference and reinitializing', () => {
+        localStorage.setItem('THEME', Themes.dark);
+        const initSpy = vi.spyOn(service, 'init');
+
+        service.setAutoMode();
+
+        expect(localStorage.getItem('THEME')).toBeNull();
+        expect(initSpy).toHaveBeenCalledTimes(1);
+        expect(service.isAutoMode()).toBe(true);
+
+        initSpy.mockRestore();
+    });
+
+    it('should report auto mode status based on stored preference', () => {
+        expect(service.isAutoMode()).toBe(true);
+
+        localStorage.setItem('THEME', Themes.light);
+
+        expect(service.isAutoMode()).toBe(false);
     });
 });


### PR DESCRIPTION
## Summary
- correct the invoice tagging request payload type
- fix SPA and API client README typos and publish command reference
- expand ThemeService tests to cover auto mode handling

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ca66485b2c832cb3faeddf3ff351eb