### PR TITLE
Fix/null pointer in az service

### DIFF
--- a/backend/app.hopps.az-document-ai/src/main/java/app/hopps/az/document/ai/AzureAiService.java
+++ b/backend/app.hopps.az-document-ai/src/main/java/app/hopps/az/document/ai/AzureAiService.java
@@ -43,6 +43,10 @@ public class AzureAiService {
         LOG.info("Scanned receipt: {}", document.get().getFields());
 
         ReceiptData receiptData = ReceiptDataHelper.fromDocument(document.get());
+        if (receiptData == null) {
+            LOG.warn("Could not extract receipt data from document '{}' - missing required fields", documentName);
+            return Optional.empty();
+        }
         return Optional.of(receiptData);
     }
 

--- a/backend/app.hopps.az-document-ai/src/main/java/app/hopps/az/document/ai/model/ReceiptDataHelper.java
+++ b/backend/app.hopps.az-document-ai/src/main/java/app/hopps/az/document/ai/model/ReceiptDataHelper.java
@@ -16,13 +16,19 @@ public class ReceiptDataHelper {
     public static ReceiptData fromDocument(AnalyzedDocument document) {
         Map<String, DocumentField> fields = document.getFields();
 
+        // Check if required "Total" field exists
+        DocumentField totalField = fields.get("Total");
+        if (totalField == null || totalField.getValueCurrency() == null) {
+            return null;
+        }
+
         DocumentField transactionTime = fields.get("TransactionTime");
 
         LocalTime time = transactionTime == null ? LocalTime.MIDNIGHT
                 : LocalTime.parse(transactionTime.getValueTime());
 
         return new ReceiptData(
-                BigDecimal.valueOf(fields.get("Total").getValueCurrency().getAmount()),
+                BigDecimal.valueOf(totalField.getValueCurrency().getAmount()),
                 Optional.ofNullable(fields.get("MerchantName")).map(DocumentField::getValueString),
                 Optional.ofNullable(fields.get("MerchantAddress"))
                         .map(DocumentField::getValueAddress)


### PR DESCRIPTION
Fixing this null pointer issu:

```
2025-11-12 15:43:05,267 ERROR [io.qua.ver.htt.run.QuarkusErrorHandler] (executor-thread-3) HTTP Request to /api/az-document-ai/document/scan/receipt failed, error id: 75c9775e-1464-4c30-823a-ad472deb4f77-2: java.lang.NullPointerException: Cannot invoke "com.azure.ai.documentintelligence.models.DocumentField.getValueCurrency()" because the return value of "java.util.Map.get(Object)" is null
	at app.hopps.az.document.ai.model.ReceiptDataHelper.fromDocument(ReceiptDataHelper.java:25)
	at app.hopps.az.document.ai.AzureAiService.scanReceipt(AzureAiService.java:45)
	at app.hopps.az.document.ai.AzureAiService_ClientProxy.scanReceipt(Unknown Source)
	at app.hopps.az.document.ai.ScanDocumentResource.scanReceipt(ScanDocumentResource.java:58)
	at app.hopps.az.document.ai.ScanDocumentResource_ClientProxy.scanReceipt(Unknown Source)
	at app.hopps.az.document.ai.ScanDocumentResource$quarkusrestinvoker$scanReceipt_fdf5aef609c66151d3c58658868ac4c343e07b41.invoke(Unknown Source)
	at org.jboss.resteasy.reactive.server.handlers.InvocationHandler.handle(InvocationHandler.java:29)
	at io.quarkus.resteasy.reactive.server.runtime.QuarkusResteasyReactiveRequestContext.invokeHandler(QuarkusResteasyReactiveRequestContext.java:141)
	at org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext.run(AbstractResteasyReactiveContext.java:147)
	at io.quarkus.vertx.core.runtime.VertxCoreRecorder$15.runWith(VertxCoreRecorder.java:638)
	at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2675)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2654)
	at org.jboss.threads.EnhancedQueueExecutor.runThreadBody(EnhancedQueueExecutor.java:1627)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1594)
	at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:11)
	at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:11)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```