### PR TITLE
fix/transaction-deletion

### DIFF
--- a/backend/app.hopps.org/src/main/java/app/hopps/document/api/DocumentResource.java
+++ b/backend/app.hopps.org/src/main/java/app/hopps/document/api/DocumentResource.java
@@ -7,6 +7,7 @@ import app.hopps.document.api.dto.DocumentUpdateRequest;
 import app.hopps.document.domain.*;
 import app.hopps.document.repository.DocumentRepository;
 import app.hopps.document.service.DocumentFileService;
+import app.hopps.document.service.TradePartyService;
 import app.hopps.organization.domain.Organization;
 import app.hopps.shared.security.OrganizationContext;
 import app.hopps.transaction.domain.Transaction;
@@ -35,8 +36,10 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * REST API for document management. Handles document upload, retrieval, and updates.
@@ -59,6 +62,9 @@ public class DocumentResource {
 
     @Inject
     TransactionRepository transactionRepository;
+
+    @Inject
+    TradePartyService tradePartyService;
 
     @Inject
     Event<DocumentCreatedEvent> documentCreatedEvent;
@@ -288,13 +294,19 @@ public class DocumentResource {
 
         // Delete associated transaction first (due to foreign key constraint)
         Transaction transaction = transactionRepository.findByDocumentId(id);
+        Set<TradeParty> parties = new LinkedHashSet<>();
         if (transaction != null) {
-            // Clean up bank-transaction matches (and recompute their status) before the row is removed.
+            // Clean up bank-transaction matches (and recompute their status) before the row is removed. The bank
+            // movement itself is kept and becomes matchable again.
             transactionDeletedEvent.fire(new TransactionDeletedEvent(transaction.getId()));
+            parties.add(transaction.getSender());
+            parties.add(transaction.getRecipient());
             transactionRepository.delete(transaction);
             LOG.info("Transaction deleted for document: transactionId={}, documentId={}",
                     transaction.getId(), id);
         }
+        parties.add(document.getSender());
+        parties.add(document.getRecipient());
 
         // Delete file from storage
         if (document.hasFile()) {
@@ -303,6 +315,11 @@ public class DocumentResource {
 
         notifyChanged(document);
         documentRepository.delete(document);
+
+        // Trade parties are shared between a document and its transaction, so they are not cascaded and need extra
+        // handling
+        parties.forEach(tradePartyService::deleteIfUnreferenced);
+
         LOG.info("Document deleted: id={}", id);
     }
 

--- a/backend/app.hopps.org/src/main/java/app/hopps/document/domain/Document.java
+++ b/backend/app.hopps.org/src/main/java/app/hopps/document/domain/Document.java
@@ -38,10 +38,10 @@ public class Document extends PanacheEntity {
 
     private Instant transactionTime;
 
-    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE }, fetch = FetchType.LAZY)
     private TradeParty sender;
 
-    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE }, fetch = FetchType.LAZY)
     private TradeParty recipient;
 
     @OneToMany(mappedBy = "document", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/backend/app.hopps.org/src/main/java/app/hopps/document/service/TradePartyService.java
+++ b/backend/app.hopps.org/src/main/java/app/hopps/document/service/TradePartyService.java
@@ -1,0 +1,62 @@
+package app.hopps.document.service;
+
+import app.hopps.document.domain.TradeParty;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Lifecycle operations for {@link TradeParty}.
+ * <p>
+ * A trade party can be shared: confirming a document hands its sender to the newly created transaction, so both rows
+ * end up pointing at the same party. The associations therefore must not cascade REMOVE — deleting one owner would try
+ * to take the party with it and break the other owner's foreign key. Ownership is managed here instead, by the delete
+ * paths handing over each side once their row is gone.
+ */
+@ApplicationScoped
+public class TradePartyService {
+    private static final Logger LOG = LoggerFactory.getLogger(TradePartyService.class);
+
+    @Inject
+    EntityManager entityManager;
+
+    /**
+     * Deletes the given trade party if no document and no transaction reference it any more. Null-safe, and a no-op
+     * while other rows still point at the party.
+     * <p>
+     * Call this <em>after</em> the owning document or transaction has been deleted, otherwise that owner still counts
+     * as a reference and the party is kept.
+     *
+     * @param party
+     *            the party to drop if it has become unreferenced; may be null
+     */
+    public void deleteIfUnreferenced(TradeParty party) {
+        if (party == null || party.id == null) {
+            return;
+        }
+
+        // Make the pending owner delete visible to the count queries below.
+        entityManager.flush();
+
+        if (countReferences(party) > 0) {
+            return;
+        }
+
+        entityManager.remove(party);
+        LOG.debug("Deleted unreferenced trade party: id={}, name={}", party.id, party.getName());
+    }
+
+    private long countReferences(TradeParty party) {
+        return count("Document", party) + count("Transaction", party);
+    }
+
+    private long count(String entityName, TradeParty party) {
+        return entityManager
+                .createQuery("SELECT COUNT(e) FROM " + entityName
+                        + " e WHERE e.sender = :party OR e.recipient = :party", Long.class)
+                .setParameter("party", party)
+                .getSingleResult();
+    }
+}

--- a/backend/app.hopps.org/src/main/java/app/hopps/transaction/api/TransactionResource.java
+++ b/backend/app.hopps.org/src/main/java/app/hopps/transaction/api/TransactionResource.java
@@ -3,8 +3,10 @@ package app.hopps.transaction.api;
 import app.hopps.bankimport.service.BankTransactionMatchService;
 import app.hopps.category.service.CategoryGroupService;
 import app.hopps.document.domain.Document;
+import app.hopps.document.domain.DocumentChangedEvent;
 import app.hopps.document.domain.DocumentStatus;
 import app.hopps.document.domain.TradeParty;
+import app.hopps.document.service.TradePartyService;
 import app.hopps.organization.domain.Organization;
 import app.hopps.shared.security.OrganizationContext;
 import app.hopps.transaction.api.dto.TransactionAggregateResponse;
@@ -80,6 +82,12 @@ public class TransactionResource {
 
     @Inject
     CategoryGroupService categoryGroupService;
+
+    @Inject
+    TradePartyService tradePartyService;
+
+    @Inject
+    Event<DocumentChangedEvent> documentChangedEvent;
 
     @GET
     @Operation(summary = "List all transactions", description = "Returns all transactions for the current organization with optional filters")
@@ -374,8 +382,8 @@ public class TransactionResource {
         // Mirror the document back to a reviewable state so it isn't shown as confirmed while its transaction is a
         // draft.
         Document document = transaction.getDocument();
-        if (document != null && document.getDocumentStatus() == DocumentStatus.CONFIRMED) {
-            document.setDocumentStatus(DocumentStatus.ANALYZED);
+        if (document != null) {
+            revertToReview(document);
         }
 
         LOG.info("Transaction reopened: id={}", transaction.getId());
@@ -397,11 +405,46 @@ public class TransactionResource {
             throw new NotFoundException("Transaction not found");
         }
 
-        // Clean up any bank-transaction matches (and recompute their status) before the row is removed.
+        // Clean up any bank-transaction matches (and recompute their status) before the row is removed. The bank
+        // movement itself is kept and becomes matchable again.
         transactionDeletedEvent.fire(new TransactionDeletedEvent(transaction.getId()));
 
+        // send the document back to review so it can be corrected and confirmed again
+        Document document = transaction.getDocument();
+        if (document != null) {
+            revertToReview(document);
+
+            // cleanup transaction from document
+            document.setTransaction(null);
+            documentChangedEvent.fire(new DocumentChangedEvent(document.getId(),
+                    document.getOrganization() != null ? document.getOrganization().getId() : null));
+        }
+
+        TradeParty sender = transaction.getSender();
+        TradeParty recipient = transaction.getRecipient();
+
         transactionRepository.delete(transaction);
-        LOG.info("Transaction deleted: id={}", id);
+
+        // Trade parties are shared with the document, so they are not cascaded
+        tradePartyService.deleteIfUnreferenced(sender);
+        tradePartyService.deleteIfUnreferenced(recipient);
+
+        LOG.info("Transaction deleted: id={}, receiptRevertedToReview={}", id, document != null);
+    }
+
+    /**
+     * Sends a document back to a reviewable state after its transaction was reopened or deleted, so it is not listed as
+     * confirmed while nothing (or only a draft) is booked behind it. {@code reviewedBy} is cleared because the document
+     * is awaiting review again.
+     *
+     * @param document
+     *            the document to revert
+     */
+    private void revertToReview(Document document) {
+        if (document.getDocumentStatus() == DocumentStatus.CONFIRMED) {
+            document.setDocumentStatus(DocumentStatus.ANALYZED);
+        }
+        document.setReviewedBy(null);
     }
 
 }

--- a/backend/app.hopps.org/src/main/java/app/hopps/transaction/domain/Transaction.java
+++ b/backend/app.hopps.org/src/main/java/app/hopps/transaction/domain/Transaction.java
@@ -69,11 +69,11 @@ public class Transaction extends PanacheEntity {
     @ColumnDefault("false")
     private boolean privatelyPaid;
 
-    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE }, fetch = FetchType.LAZY)
     @JoinColumn(name = "sender_id")
     private TradeParty sender;
 
-    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE }, fetch = FetchType.LAZY)
     @JoinColumn(name = "recipient_id")
     private TradeParty recipient;
 

--- a/backend/app.hopps.org/src/test/java/app/hopps/document/api/DocumentResourceTest.java
+++ b/backend/app.hopps.org/src/test/java/app/hopps/document/api/DocumentResourceTest.java
@@ -1,7 +1,9 @@
 package app.hopps.document.api;
 
 import app.hopps.document.domain.AnalysisStatus;
+import app.hopps.document.domain.DocumentStatus;
 import app.hopps.document.service.DocumentAnalysisService;
+import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
@@ -9,6 +11,7 @@ import io.quarkus.test.security.TestSecurity;
 import io.quarkus.test.security.oidc.Claim;
 import io.quarkus.test.security.oidc.OidcSecurity;
 import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -23,7 +26,10 @@ import java.nio.charset.StandardCharsets;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
@@ -48,8 +54,13 @@ class DocumentResourceTest {
     @Inject
     S3Client s3Client;
 
+    @Inject
+    EntityManager entityManager;
+
     @ConfigProperty(name = "bucket.name")
     String bucketName;
+
+    private static final String SENDER_NAME = "Appointmed GmbH";
 
     @BeforeEach
     void setup() {
@@ -302,5 +313,171 @@ class DocumentResourceTest {
                 .body("senderName", equalTo("Test Company"))
                 .body("privatelyPaid", equalTo(true))
                 .body("extractionSource", equalTo("MANUAL"));
+    }
+
+    @Test
+    void shouldDeleteTransactionOnlyAndReturnReceiptToReview() {
+        ConfirmedReceipt receipt = uploadAndConfirmWithSender();
+
+        given()
+                .basePath("/transactions")
+                .when()
+                .delete("/{id}", receipt.transactionId())
+                .then()
+                .statusCode(Response.Status.NO_CONTENT.getStatusCode());
+
+        // The receipt outlives its transaction: reviewable again, sender untouched, no longer claiming to be booked.
+        given()
+                .when()
+                .get("/{id}", receipt.documentId())
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .body("documentStatus", equalTo(DocumentStatus.ANALYZED.name()))
+                .body("transactionId", nullValue())
+                .body("senderName", equalTo(SENDER_NAME));
+
+        assertNull(reviewedBy(receipt.documentId()), "reviewedBy should be cleared when a receipt returns to review");
+    }
+
+    @Test
+    void shouldCreateANewTransactionWhenReconfirmingAfterTransactionOnlyDelete() {
+        ConfirmedReceipt receipt = uploadAndConfirmWithSender();
+
+        given()
+                .basePath("/transactions")
+                .when()
+                .delete("/{id}", receipt.transactionId())
+                .then()
+                .statusCode(Response.Status.NO_CONTENT.getStatusCode());
+
+        // Guards the confirm shortcut that skips creating a transaction while one is still linked - a stale link would
+        // leave the receipt CONFIRMED with nothing booked behind it.
+        Integer newTransactionId = given()
+                .when()
+                .post("/{id}/confirm", receipt.documentId())
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .body("documentStatus", equalTo(DocumentStatus.CONFIRMED.name()))
+                .body("transactionId", notNullValue())
+                .extract()
+                .path("transactionId");
+
+        assertNotEquals(receipt.transactionId(), newTransactionId.longValue());
+    }
+
+    @Test
+    void shouldDeleteReceiptAndTransactionTogether() {
+        ConfirmedReceipt receipt = uploadAndConfirmWithSender();
+
+        given()
+                .when()
+                .delete("/{id}", receipt.documentId())
+                .then()
+                .statusCode(Response.Status.NO_CONTENT.getStatusCode());
+
+        given()
+                .when()
+                .get("/{id}", receipt.documentId())
+                .then()
+                .statusCode(Response.Status.NOT_FOUND.getStatusCode());
+
+        given()
+                .basePath("/transactions")
+                .when()
+                .get("/{id}", receipt.transactionId())
+                .then()
+                .statusCode(Response.Status.NOT_FOUND.getStatusCode());
+    }
+
+    @Test
+    void shouldDropTradePartiesOnceNothingReferencesThem() {
+        long before = countTradeParties();
+
+        ConfirmedReceipt receipt = uploadAndConfirmWithSender();
+        // The receipt's sender, plus the organization side recorded on the transaction.
+        assertEquals(before + 2, countTradeParties());
+
+        given()
+                .basePath("/transactions")
+                .when()
+                .delete("/{id}", receipt.transactionId())
+                .then()
+                .statusCode(Response.Status.NO_CONTENT.getStatusCode());
+
+        // The organization side is unreferenced and dropped; the sender survives because the receipt still holds it.
+        assertEquals(before + 1, countTradeParties());
+
+        given()
+                .when()
+                .delete("/{id}", receipt.documentId())
+                .then()
+                .statusCode(Response.Status.NO_CONTENT.getStatusCode());
+
+        assertEquals(before, countTradeParties());
+    }
+
+    /**
+     * Uploads a receipt, gives it a sender and confirms it. Confirm hands that very TradeParty to the new transaction,
+     * so both rows share one party - the case the delete paths have to cope with.
+     */
+    private ConfirmedReceipt uploadAndConfirmWithSender() {
+        InputStream pdf = getClass().getClassLoader().getResourceAsStream("ZUGFeRD.pdf");
+        assertNotNull(pdf);
+
+        Integer documentId = given()
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .multiPart("file", "ZUGFeRD.pdf", pdf, "application/pdf")
+                .when()
+                .post()
+                .then()
+                .statusCode(Response.Status.CREATED.getStatusCode())
+                .extract()
+                .path("id");
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("""
+                        {
+                            "name": "Kassenbeleg",
+                            "total": 180.00,
+                            "senderName": "%s",
+                            "senderCity": "Wien",
+                            "privatelyPaid": false
+                        }
+                        """.formatted(SENDER_NAME))
+                .when()
+                .patch("/{id}", documentId)
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .body("senderName", equalTo(SENDER_NAME));
+
+        Integer transactionId = given()
+                .when()
+                .post("/{id}/confirm", documentId)
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .body("documentStatus", equalTo(DocumentStatus.CONFIRMED.name()))
+                .body("transactionId", notNullValue())
+                .extract()
+                .path("transactionId");
+
+        return new ConfirmedReceipt(documentId.longValue(), transactionId.longValue());
+    }
+
+    private String reviewedBy(long documentId) {
+        return QuarkusTransaction.requiringNew()
+                .call(() -> entityManager
+                        .createQuery("SELECT d.reviewedBy FROM Document d WHERE d.id = :id", String.class)
+                        .setParameter("id", documentId)
+                        .getSingleResult());
+    }
+
+    private long countTradeParties() {
+        return QuarkusTransaction.requiringNew()
+                .call(() -> entityManager.createQuery("SELECT COUNT(t) FROM TradeParty t", Long.class)
+                        .getSingleResult());
+    }
+
+    private record ConfirmedReceipt(long documentId, long transactionId) {
     }
 }

--- a/frontend/spa/src/components/Receipts/DeleteTransactionDialog.tsx
+++ b/frontend/spa/src/components/Receipts/DeleteTransactionDialog.tsx
@@ -1,44 +1,97 @@
 import { AlertTriangle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
-import Button from '@/components/ui/Button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
 
 export interface DeleteTransactionDialogProps {
     open: boolean;
     transactionName: string;
     transactionAmount: string;
-    onConfirm: () => void;
+    /** Replaces the "delete '<name>' (<amount>)?" sentence — used by the bulk path, which deletes several at once. */
+    description?: string;
+    /** Whether a receipt is linked. Without one, both delete options would do the same thing, so only one is offered. */
+    hasReceipt: boolean;
+    onDeleteTransactionOnly: () => void;
+    onDeleteWithReceipt: () => void;
     onCancel: () => void;
 }
 
-export function DeleteTransactionDialog({ open, transactionName, transactionAmount, onConfirm, onCancel }: DeleteTransactionDialogProps) {
+// The app's pill buttons. Each option's card is tinted to match its button so the colour alone says which is which:
+// neutral = the receipt survives, red = everything goes.
+const PILL = 'inline-flex items-center gap-1.5 px-4 py-2 rounded-full text-[14px] font-bold transition-colors';
+const NEUTRAL_BUTTON = `${PILL} border border-[#E0E0E6] text-[#1B1B1F] hover:bg-[#F8F8FA]`;
+const DESTRUCTIVE_BUTTON = `${PILL} bg-[#FBEAEF] text-[#B12C4C] hover:bg-[#F5D9E1]`;
+const GHOST_BUTTON = `${PILL} text-[#6B6B76] hover:bg-[#F8F8FA]`;
+
+export function DeleteTransactionDialog({
+    open,
+    transactionName,
+    transactionAmount,
+    description,
+    hasReceipt,
+    onDeleteTransactionOnly,
+    onDeleteWithReceipt,
+    onCancel,
+}: DeleteTransactionDialogProps) {
     const { t } = useTranslation();
 
     return (
         <Dialog open={open} onOpenChange={(open) => !open && onCancel()}>
-            <DialogContent className="sm:max-w-[450px]">
+            {/* min-w-0 keeps the grid children from widening the panel past its max-width (grid items default to
+                min-width:auto, so the button row would otherwise push the content out over the background). */}
+            <DialogContent className="sm:max-w-[580px] [&>*]:min-w-0">
                 <DialogHeader>
                     <DialogTitle className="flex items-center gap-2">
                         <AlertTriangle className="w-5 h-5 text-orange-500" />
                         {t('receipts.deleteDialog.title')}
                     </DialogTitle>
-                    <DialogDescription>{t('receipts.deleteDialog.description', { name: transactionName, amount: transactionAmount })}</DialogDescription>
+                    <DialogDescription>
+                        {/* Not every transaction has a name — quoting an empty string reads as a bug, so drop the name entirely. */}
+                        {description ??
+                            (transactionName.trim()
+                                ? t('receipts.deleteDialog.description', { name: transactionName, amount: transactionAmount })
+                                : t('receipts.deleteDialog.descriptionNoName', { amount: transactionAmount }))}
+                    </DialogDescription>
                 </DialogHeader>
 
-                <div className="py-4">
-                    <div className="bg-orange-50 border border-orange-200 rounded-lg p-4">
-                        <p className="text-sm text-orange-800 font-medium">{t('receipts.deleteDialog.warning')}</p>
+                {hasReceipt ? (
+                    <div className="flex flex-col gap-2">
+                        <div className="rounded-lg border border-[#E0E0E6] bg-[#F8F8FA] p-3">
+                            <p className="text-sm font-bold text-[#1B1B1F]">{t('receipts.deleteDialog.confirmTransactionOnly')}</p>
+                            <p className="text-sm text-[#6B6B76]">{t('receipts.deleteDialog.optionTransactionOnly')}</p>
+                        </div>
+                        <div className="rounded-lg border border-[#E8A0B2] bg-[#FBEAEF] p-3">
+                            <p className="text-sm font-bold text-[#B12C4C]">{t('receipts.deleteDialog.confirmWithReceipt')}</p>
+                            <p className="text-sm text-[#B12C4C]">{t('receipts.deleteDialog.optionWithReceipt')}</p>
+                        </div>
                     </div>
-                </div>
+                ) : (
+                    <div className="rounded-lg border border-[#E8A0B2] bg-[#FBEAEF] p-4">
+                        <p className="text-sm font-bold text-[#B12C4C]">{t('receipts.deleteDialog.warning')}</p>
+                    </div>
+                )}
 
-                <DialogFooter>
-                    <Button variant="outline" onClick={onCancel}>
+                {/* The panel is sized so all three fit on one row in German; flex-wrap stays as a fallback for
+                    narrower viewports and longer translations. gap replaces the default space-x, which would
+                    misalign a wrapped line. */}
+                <DialogFooter className="sm:flex-wrap sm:gap-2 sm:space-x-0">
+                    <button type="button" className={GHOST_BUTTON} onClick={onCancel}>
                         {t('common.cancel')}
-                    </Button>
-                    <Button variant="destructive" onClick={onConfirm}>
-                        {t('receipts.deleteDialog.confirm')}
-                    </Button>
+                    </button>
+                    {hasReceipt ? (
+                        <>
+                            <button type="button" className={NEUTRAL_BUTTON} onClick={onDeleteTransactionOnly}>
+                                {t('receipts.deleteDialog.confirmTransactionOnly')}
+                            </button>
+                            <button type="button" className={DESTRUCTIVE_BUTTON} onClick={onDeleteWithReceipt}>
+                                {t('receipts.deleteDialog.confirmWithReceipt')}
+                            </button>
+                        </>
+                    ) : (
+                        <button type="button" className={DESTRUCTIVE_BUTTON} onClick={onDeleteTransactionOnly}>
+                            {t('receipts.deleteDialog.confirm')}
+                        </button>
+                    )}
                 </DialogFooter>
             </DialogContent>
         </Dialog>

--- a/frontend/spa/src/components/Receipts/ReceiptsList.tsx
+++ b/frontend/spa/src/components/Receipts/ReceiptsList.tsx
@@ -11,6 +11,7 @@ import ReceiptsEmptyState from '@/components/Receipts/ReceiptsEmptyState';
 import ReceiptsTableHeader from '@/components/Receipts/ReceiptsTableHeader';
 import { Receipt, ReceiptFiltersState } from '@/components/Receipts/types';
 import { BaseButton } from '@/components/ui/shadecn/BaseButton';
+import { useDeleteDocument } from '@/hooks/queries/useDocuments';
 import { transactionToReceipt, useDeleteTransaction, useTransactions } from '@/hooks/queries/useTransactions';
 import { useToast } from '@/hooks/use-toast';
 import { useBommelsStore } from '@/store/bommels/bommelsStore';
@@ -28,6 +29,7 @@ const ReceiptsList: FC<ReceiptsListProps> = ({ filters }) => {
     const pageSize = 10;
     const [deleteTarget, setDeleteTarget] = useState<Receipt | null>(null);
     const deleteTransaction = useDeleteTransaction();
+    const deleteDocument = useDeleteDocument();
 
     // Map UI filters to API filters
     const apiFilters = useMemo(() => {
@@ -116,21 +118,34 @@ const ReceiptsList: FC<ReceiptsListProps> = ({ filters }) => {
 
     const deletingRef = useRef(false);
 
-    const handleDeleteConfirm = useCallback(async () => {
-        if (!deleteTarget) return;
-        if (deletingRef.current) return;
-        deletingRef.current = true;
-        try {
-            await deleteTransaction.mutateAsync(parseInt(deleteTarget.id, 10));
-            setDeleteTarget(null);
-            showSuccess(t('receipts.deleteDialog.success'));
-        } catch (e) {
-            console.error(e);
-            showError(t('receipts.deleteDialog.error'));
-        } finally {
-            deletingRef.current = false;
-        }
-    }, [deleteTarget, deleteTransaction, showError, showSuccess, t]);
+    // Two ways out: drop only the booking and leave the receipt to be reviewed again, or delete both. Deleting the
+    // document deletes its transaction along with it, so the second case is a single call to the document endpoint.
+    const runDelete = useCallback(
+        async (withReceipt: boolean) => {
+            if (!deleteTarget) return;
+            if (deletingRef.current) return;
+            deletingRef.current = true;
+            try {
+                if (withReceipt && deleteTarget.documentId !== null) {
+                    await deleteDocument.mutateAsync(deleteTarget.documentId);
+                    showSuccess(t('receipts.deleteDialog.successWithReceipt'));
+                } else {
+                    await deleteTransaction.mutateAsync(parseInt(deleteTarget.id, 10));
+                    showSuccess(deleteTarget.documentId !== null ? t('receipts.deleteDialog.successTransactionOnly') : t('receipts.deleteDialog.success'));
+                }
+                setDeleteTarget(null);
+            } catch (e) {
+                console.error(e);
+                showError(t('receipts.deleteDialog.error'));
+            } finally {
+                deletingRef.current = false;
+            }
+        },
+        [deleteTarget, deleteDocument, deleteTransaction, showError, showSuccess, t]
+    );
+
+    const handleDeleteTransactionOnly = useCallback(() => runDelete(false), [runDelete]);
+    const handleDeleteWithReceipt = useCallback(() => runDelete(true), [runDelete]);
 
     const handleDeleteCancel = useCallback(() => {
         setDeleteTarget(null);
@@ -227,7 +242,9 @@ const ReceiptsList: FC<ReceiptsListProps> = ({ filters }) => {
                 open={!!deleteTarget}
                 transactionName={deleteTarget?.issuer || ''}
                 transactionAmount={deleteTarget ? formatAmount(deleteTarget.amount) : ''}
-                onConfirm={handleDeleteConfirm}
+                hasReceipt={deleteTarget?.documentId != null}
+                onDeleteTransactionOnly={handleDeleteTransactionOnly}
+                onDeleteWithReceipt={handleDeleteWithReceipt}
                 onCancel={handleDeleteCancel}
             />
         </div>

--- a/frontend/spa/src/components/views/TransactionenView.tsx
+++ b/frontend/spa/src/components/views/TransactionenView.tsx
@@ -30,14 +30,14 @@ import { buildBommelIndex, missingRequiredGroups } from '@/components/CategoryGr
 import TransactionCategoryFilter from '@/components/CategoryGroups/TransactionCategoryFilter';
 import { LoadingState } from '@/components/common/LoadingState';
 import InvoiceUploadFormBommelSelector, { getLastBommelId } from '@/components/InvoiceUploadForm/InvoiceUploadFormBommelSelector';
+import { DeleteTransactionDialog } from '@/components/Receipts/DeleteTransactionDialog';
 import { DocumentFilePreview } from '@/components/Receipts/DocumentFilePreview';
 import { BankMatchSection } from '@/components/Transactions/BankMatchSection';
-import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { HintTooltip } from '@/components/ui/HintTooltip';
 import { SortHeader } from '@/components/ui/SortHeader';
 import { useBankTransactionsForTransaction } from '@/hooks/queries/useBankAccounts';
 import { useCategoryGroups } from '@/hooks/queries/useCategoryGroups';
-import { useDocument } from '@/hooks/queries/useDocuments';
+import { useDeleteDocument, useDocument } from '@/hooks/queries/useDocuments';
 import {
     useTransactions,
     useTransactionAggregate,
@@ -163,6 +163,7 @@ function TransactionDrawer({ txId, onClose, onDeleted }: { txId: number | null; 
     // mirroring the receipt detail view. Fetching is gated on documentId (the hook no-ops when it's undefined).
     const { data: linkedDoc } = useDocument(tx?.documentId ?? undefined);
     const deleteMutation = useDeleteTransaction();
+    const deleteDocumentMutation = useDeleteDocument();
     const updateMutation = useUpdateTransaction();
     const confirmMutation = useConfirmTransaction();
     const reopenMutation = useReopenTransaction();
@@ -290,9 +291,14 @@ function TransactionDrawer({ txId, onClose, onDeleted }: { txId: number | null; 
         onClose();
     }
 
-    async function handleDelete() {
+    // Deleting the document takes its transaction with it, so "with receipt" is a single call to the document endpoint.
+    async function handleDelete(withReceipt: boolean) {
         if (!txId) return;
-        await deleteMutation.mutateAsync(txId);
+        if (withReceipt && tx?.documentId != null) {
+            await deleteDocumentMutation.mutateAsync(tx.documentId);
+        } else {
+            await deleteMutation.mutateAsync(txId);
+        }
         setConfirmDeleteOpen(false);
         onDeleted();
         onClose();
@@ -702,16 +708,14 @@ function TransactionDrawer({ txId, onClose, onDeleted }: { txId: number | null; 
                 )}
             </div>
 
-            <ConfirmDialog
+            <DeleteTransactionDialog
                 open={confirmDeleteOpen}
-                onOpenChange={setConfirmDeleteOpen}
-                title={t('transactions.detail.deleteConfirmTitle')}
-                description={t('transactions.detail.deleteConfirmText')}
-                confirmLabel={t('transactions.detail.delete')}
-                cancelLabel={t('transactions.detail.cancel')}
-                onConfirm={handleDelete}
-                destructive
-                loading={deleteMutation.isPending}
+                transactionName={tx?.name || tx?.senderName || ''}
+                transactionAmount={fmtCurrency(tx?.total)}
+                hasReceipt={tx?.documentId != null}
+                onDeleteTransactionOnly={() => handleDelete(false)}
+                onDeleteWithReceipt={() => handleDelete(true)}
+                onCancel={() => setConfirmDeleteOpen(false)}
             />
         </>
     );
@@ -874,6 +878,7 @@ export function TransactionenView() {
     const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
     const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
     const bulkDelete = useDeleteTransaction();
+    const deleteDocumentBulk = useDeleteDocument();
     const PAGE_SIZE = 30;
 
     // Open a specific transaction when navigated to with ?id= (e.g. from a linked receipt)
@@ -975,10 +980,28 @@ export function TransactionenView() {
 
     const clearSelection = () => setSelectedIds(new Set());
 
-    const handleBulkDelete = async () => {
+    // documentId per selected row, for the "with receipts" branch. Only the loaded page is known here; a selection
+    // carried over from another page falls back to a transaction-only delete, so no receipt is removed unseen.
+    const selectedDocumentIds = useMemo(() => {
+        const byId = new Map<number, number | null>();
+        (txData ?? []).forEach((tx) => {
+            if (tx.id != null && selectedIds.has(tx.id)) byId.set(tx.id, tx.documentId ?? null);
+        });
+        return byId;
+    }, [txData, selectedIds]);
+
+    const selectionHasReceipts = Array.from(selectedDocumentIds.values()).some((docId) => docId != null);
+
+    const handleBulkDelete = async (withReceipts: boolean) => {
         const ids = Array.from(selectedIds);
         // allSettled so one failed delete doesn't abort the rest; the list refetches via query invalidation.
-        await Promise.allSettled(ids.map((id) => bulkDelete.mutateAsync(id)));
+        await Promise.allSettled(
+            ids.map((id) => {
+                const documentId = withReceipts ? selectedDocumentIds.get(id) : null;
+                // Deleting the document removes its transaction too, so rows with a receipt need only that one call.
+                return documentId != null ? deleteDocumentBulk.mutateAsync(documentId) : bulkDelete.mutateAsync(id);
+            })
+        );
         if (selectedTxId != null && selectedIds.has(selectedTxId)) setSelectedTxId(null);
         clearSelection();
         setBulkDeleteOpen(false);
@@ -1423,16 +1446,15 @@ export function TransactionenView() {
             {/* Create transaction drawer */}
             <CreateTransactionDrawer open={createOpen} onClose={() => setCreateOpen(false)} />
 
-            <ConfirmDialog
+            <DeleteTransactionDialog
                 open={bulkDeleteOpen}
-                onOpenChange={setBulkDeleteOpen}
-                title={t('transactions.bulk.confirmTitle')}
+                transactionName=""
+                transactionAmount=""
                 description={t('transactions.bulk.confirmDesc', { n: selectedIds.size })}
-                confirmLabel={t('transactions.bulk.delete')}
-                cancelLabel={t('common.cancel')}
-                onConfirm={handleBulkDelete}
-                destructive
-                loading={bulkDelete.isPending}
+                hasReceipt={selectionHasReceipts}
+                onDeleteTransactionOnly={() => handleBulkDelete(false)}
+                onDeleteWithReceipt={() => handleBulkDelete(true)}
+                onCancel={() => setBulkDeleteOpen(false)}
             />
         </div>
     );

--- a/frontend/spa/src/hooks/queries/useTransactions.ts
+++ b/frontend/spa/src/hooks/queries/useTransactions.ts
@@ -168,6 +168,8 @@ export function useDeleteTransaction() {
             queryClient.invalidateQueries({ queryKey: transactionKeys.all });
             // Deleting a transaction may unmatch a bank transaction (status reset on the backend) — refresh those too.
             queryClient.invalidateQueries({ queryKey: ['bankTransactions'] });
+            // A linked receipt survives and returns to review state — refresh documents so it reappears there.
+            queryClient.invalidateQueries({ queryKey: ['documents'] });
         },
     });
 }

--- a/frontend/spa/src/locales/de.json
+++ b/frontend/spa/src/locales/de.json
@@ -787,7 +787,14 @@
             "warning": "Diese Aktion kann nicht rückgängig gemacht werden. Der Beleg wird dauerhaft gelöscht.",
             "confirm": "Ja, löschen",
             "error": "Fehler beim Löschen des Belegs",
-            "success": "Beleg erfolgreich gelöscht"
+            "success": "Beleg erfolgreich gelöscht",
+            "optionTransactionOnly": "Nur die Buchung wird entfernt. Der Beleg bleibt erhalten und wartet wieder auf Prüfung.",
+            "optionWithReceipt": "Buchung und Beleg werden dauerhaft gelöscht, inklusive der hochgeladenen Datei.",
+            "confirmTransactionOnly": "Nur Transaktion löschen",
+            "confirmWithReceipt": "Mit Beleg löschen",
+            "successTransactionOnly": "Transaktion gelöscht – der Beleg wartet wieder auf Prüfung",
+            "successWithReceipt": "Beleg und Transaktion gelöscht",
+            "descriptionNoName": "Sind Sie sicher, dass Sie diese Transaktion ({{amount}}) löschen möchten?"
         },
         "title": "Belege",
         "subtitle": "{{count}} ungeprüfte Belege",

--- a/frontend/spa/src/locales/en.json
+++ b/frontend/spa/src/locales/en.json
@@ -861,7 +861,14 @@
             "warning": "This action cannot be undone. The receipt will be permanently deleted.",
             "confirm": "Yes, delete",
             "error": "Failed to delete receipt",
-            "success": "Receipt successfully deleted"
+            "success": "Receipt successfully deleted",
+            "optionTransactionOnly": "Only the booking is removed. The receipt is kept and returns to review.",
+            "optionWithReceipt": "Booking and receipt are permanently deleted, including the uploaded file.",
+            "confirmTransactionOnly": "Delete transaction only",
+            "confirmWithReceipt": "Delete with receipt",
+            "successTransactionOnly": "Transaction deleted - the receipt is awaiting review again",
+            "successWithReceipt": "Receipt and transaction deleted",
+            "descriptionNoName": "Are you sure you want to delete this transaction ({{amount}})?"
         },
         "title": "Receipts",
         "subtitle": "{{count}} unreviewed receipts",

--- a/frontend/spa/vite.config.ts
+++ b/frontend/spa/vite.config.ts
@@ -11,5 +11,8 @@ export default defineConfig({
             '@': path.resolve(__dirname, './src'),
         },
     },
-    server: {},
+    server: {
+        port: 5173,
+        strictPort: true,
+    },
 });


### PR DESCRIPTION

**Ursache:** Beim Bestätigen übernimmt die neue Transaktion den Absender des Belegs, beide
Zeilen zeigen also auf **dieselbe** `trade_party`. Durch `@ManyToOne(cascade = ALL)` versuchte
das Löschen der Transaktion, diesen geteilten Datensatz mitzulöschen, obwohl der Beleg ihn
noch referenziert.

**Lösung:** Cascade auf `PERSIST, MERGE` reduziert; Trade Parties werden erst gelöscht, wenn
sie niemand mehr referenziert. Zusätzlich bleibt der Beleg beim Löschen der Transaktion
erhalten und kehrt zur Prüfung zurück,  wahlweise lässt sich der Beleg mitlöschen.

**Testplan:**

**Vorbereitung:** Beleg hochladen, **Absender setzen** (ohne Absender tritt der Fehler nicht auf), bestätigen.

- [ ] **Nur Transaktion löschen** → kein Fehler; Transaktion weg, Beleg bleibt und steht wieder auf „Bereit"
- [ ] **Erneut bestätigen** → es entsteht eine **neue** Transaktion mit anderer ID
- [ ] **Mit Beleg löschen** → Transaktion und Beleg weg, Datei aus dem Storage entfernt
- [ ] **Transaktion ohne Beleg** → Dialog zeigt nur einen Button, keine Optionen
- [ ] **Mehrfachauswahl** (mind. eine Zeile mit Beleg) → beide Optionen greifen
- [ ] **Bankabgleich** → Bankbewegung bleibt bestehen und ist wieder zuordenbar
- [ ] **Wieder öffnen** → Transaktion auf Entwurf, Beleg auf „Bereit"
- [ ] **Beleg-Liste**: Beleg löschen entfernt auch die Transaktion (unverändert)

