### PR TITLE
Fix/dashboard

### DIFF
--- a/frontend/spa/src/components/Dashboard/BommelSelect.tsx
+++ b/frontend/spa/src/components/Dashboard/BommelSelect.tsx
@@ -72,14 +72,16 @@ export function BommelSelect({ items, value, onChange, isLoading, emptyLabel, tr
         >
             <PopoverTrigger asChild>
                 <BaseButton
-                    variant="outline"
+                    variant="ghost"
                     role="combobox"
                     aria-expanded={open}
                     aria-label={t('dashboard.bommelSelect.label')}
                     disabled={isLoading}
                     data-testid="dashboard-bommel-filter"
                     className={cn(
-                        'h-10 w-full justify-between rounded-[13px] border-border-soft bg-background-secondary px-3 text-sm font-semibold text-foreground sm:w-[200px]',
+                        // variant="ghost" avoids the "outline" variant's shadow-card, which doesn't match the shadow-less
+                        // look of the other dashboard filters (e.g. PeriodSelect) — its own hover bg/text are neutralized below.
+                        'h-10 w-full justify-between rounded-[13px] border border-border-soft bg-background-secondary px-3 text-sm font-semibold text-foreground hover:bg-background-secondary hover:text-foreground sm:w-[200px]',
                         triggerClassName
                     )}
                 >

--- a/frontend/spa/src/components/Dashboard/KpiCard.tsx
+++ b/frontend/spa/src/components/Dashboard/KpiCard.tsx
@@ -73,7 +73,7 @@ export function KpiCard({ label, value, context, tone = 'neutral', icon: Icon, i
                     )}
                 </div>
             ) : (
-                <p className={cn('mt-2 text-xs font-bold', tone === 'positive' ? 'text-[var(--positive)]' : 'text-muted-foreground')}>{context}</p>
+                <p className={cn('mt-2 text-xs font-bold', tone === 'positive' ? 'text-[var(--positive)]' : 'text-muted-foreground/70')}>{context}</p>
             )}
         </Card>
     );

--- a/frontend/spa/src/components/Dashboard/hooks.ts
+++ b/frontend/spa/src/components/Dashboard/hooks.ts
@@ -23,8 +23,6 @@ export function useBankBalance(organizationId: number | undefined) {
             };
         },
         enabled: organizationId != null,
-        // Bookings made elsewhere (e.g. correcting a transaction's date) should show up the moment you land back on
-        // the dashboard, not just after the global 5-minute staleTime lapses — so every mount refetches regardless.
         refetchOnMount: 'always',
     });
 }

--- a/frontend/spa/src/components/Dashboard/hooks.ts
+++ b/frontend/spa/src/components/Dashboard/hooks.ts
@@ -23,6 +23,9 @@ export function useBankBalance(organizationId: number | undefined) {
             };
         },
         enabled: organizationId != null,
+        // Bookings made elsewhere (e.g. correcting a transaction's date) should show up the moment you land back on
+        // the dashboard, not just after the global 5-minute staleTime lapses — so every mount refetches regardless.
+        refetchOnMount: 'always',
     });
 }
 
@@ -57,6 +60,7 @@ export function useYearTotals(organizationId: number | undefined) {
             };
         },
         enabled: organizationId != null,
+        refetchOnMount: 'always',
     });
 }
 
@@ -73,6 +77,7 @@ export function useOpenReceiptsCount(organizationId: number | undefined) {
             return documents.filter((document) => document.documentStatus !== 'CONFIRMED').length;
         },
         enabled: organizationId != null,
+        refetchOnMount: 'always',
     });
 }
 
@@ -134,5 +139,6 @@ export function useIncomeExpenseSeries(organizationId: number | undefined, bomme
             };
         },
         enabled: organizationId != null,
+        refetchOnMount: 'always',
     });
 }


### PR DESCRIPTION
- Align the Bommel filter's trigger style with the other dashboard filters (removed a stray box-shadow it didn't share with PeriodSelect)
- Dashboard KPIs and chart now refetch on every visit instead of serving up to 5 minutes of stale cached data
- Lighten the KPI cards' secondary caption text (e.g. "Aktuell verfügbar")