### PR TITLE
fix/bank-import-ui-polish

### DIFF
--- a/frontend/spa/src/components/BankAccounts/BankTxFilterBar.tsx
+++ b/frontend/spa/src/components/BankAccounts/BankTxFilterBar.tsx
@@ -1,9 +1,8 @@
-import { Search, SlidersHorizontal, X } from 'lucide-react';
-import { useState } from 'react';
+import { Filter, Search, X } from 'lucide-react';
+import { ReactNode, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { BankTxFilterState } from '@/hooks/useBankTxFilters';
-import { cn } from '@/lib/utils';
 
 const inputCls =
     'w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-2.5 py-1.5 text-sm text-foreground placeholder:text-muted-foreground outline-none focus:border-primary/50 focus:ring-2 focus:ring-primary/10 transition-colors';
@@ -13,7 +12,7 @@ const fieldLabelCls = 'block text-[11px] font-bold uppercase tracking-wide text-
  * Renders the search box plus a toggle that reveals the column filters (booking-date range and amount-magnitude range)
  * for a bank-transaction feed. Filter changes propagate immediately (no debounce, matching the detail-view search).
  */
-export function BankTxFilterBar({ filters }: { filters: BankTxFilterState }) {
+export function BankTxFilterBar({ filters, actions }: { filters: BankTxFilterState; actions?: ReactNode }) {
     const { t } = useTranslation();
     // Auto-open the panel when a cached column filter is already active, so the user sees why the list is narrowed.
     const [open, setOpen] = useState(filters.columnFilterCount > 0);
@@ -21,21 +20,21 @@ export function BankTxFilterBar({ filters }: { filters: BankTxFilterState }) {
     return (
         <div className="flex flex-col gap-2">
             <div className="flex items-center gap-2">
-                {/* Search */}
-                <div className="flex flex-1 items-center gap-2 px-3 py-2 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
-                    <Search className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+                {/* Search — same look as the Transaktionen page's search field. */}
+                <div className="relative flex-1 min-w-0">
+                    <Search size={17} className="absolute left-3.5 top-1/2 -translate-y-1/2 text-[var(--ink-faint)] pointer-events-none" />
                     <input
                         type="text"
                         value={filters.search}
                         onChange={(e) => filters.setSearch(e.target.value)}
                         placeholder={t('konten.filter.searchPlaceholder')}
-                        className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
+                        className="h-9 w-full rounded-xl border border-border-soft bg-[var(--background-secondary)] pl-[38px] pr-9 text-[14.5px] text-foreground transition-shadow placeholder:text-muted-foreground/60 focus:border-primary focus:outline-none focus:ring-[3px] focus:ring-[var(--accent-surface)]"
                     />
                     {filters.search && (
                         <button
                             type="button"
                             onClick={() => filters.setSearch('')}
-                            className="text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
+                            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
                             aria-label={t('konten.filter.clearSearch')}
                         >
                             <X className="w-3.5 h-3.5" />
@@ -43,29 +42,48 @@ export function BankTxFilterBar({ filters }: { filters: BankTxFilterState }) {
                     )}
                 </div>
 
-                {/* Column-filter toggle */}
+                {/* Column-filter toggle — same look as the Transaktionen page's filter button. */}
                 <button
                     type="button"
                     onClick={() => setOpen((o) => !o)}
-                    className={cn(
-                        'flex items-center gap-2 px-3 py-2 rounded-xl border text-sm font-medium transition-colors',
-                        open || filters.columnFilterCount > 0
-                            ? 'border-primary/40 bg-primary/5 text-primary'
-                            : 'border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-muted-foreground hover:text-foreground'
-                    )}
+                    aria-expanded={open}
+                    className="inline-flex h-9 items-center gap-[7px] whitespace-nowrap font-semibold transition-colors"
+                    style={{
+                        fontSize: 13.5,
+                        padding: '0 14px',
+                        borderRadius: 9,
+                        border: '1px solid',
+                        borderColor: open ? 'transparent' : 'var(--border-soft)',
+                        background: open ? 'var(--purple-100)' : 'var(--background-secondary)',
+                        color: open ? 'var(--purple-700)' : 'var(--muted-foreground)',
+                    }}
                 >
-                    <SlidersHorizontal className="w-4 h-4" />
+                    <Filter size={15} />
                     <span className="hidden sm:inline">{t('konten.filter.filters')}</span>
                     {filters.columnFilterCount > 0 && (
-                        <span className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-primary text-primary-foreground text-[11px] font-bold">
+                        <span
+                            className="grid place-items-center rounded-full px-[5px] font-extrabold"
+                            style={{
+                                minWidth: 20,
+                                height: 20,
+                                fontSize: 11.5,
+                                background: open ? 'var(--primary)' : 'var(--accent-surface)',
+                                color: open ? '#FFFFFF' : 'var(--purple-700)',
+                            }}
+                        >
                             {filters.columnFilterCount}
                         </span>
                     )}
                 </button>
+
+                {actions}
             </div>
 
             {open && (
-                <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 p-3 rounded-xl border border-gray-100 dark:border-gray-700 bg-gray-50/60 dark:bg-gray-800/40">
+                <div
+                    className="grid grid-cols-2 sm:grid-cols-4 gap-3 rounded-[18px] border border-border-soft p-4"
+                    style={{ background: 'var(--background-secondary)', boxShadow: '0 1px 2px rgba(20,20,40,.05), 0 6px 22px rgba(20,20,40,.05)' }}
+                >
                     <div>
                         <label className={fieldLabelCls}>{t('konten.filter.dateFrom')}</label>
                         <input type="date" value={filters.dateFrom} onChange={(e) => filters.setDateFrom(e.target.value)} className={inputCls} />

--- a/frontend/spa/src/components/BankAccounts/ImportWizard.tsx
+++ b/frontend/spa/src/components/BankAccounts/ImportWizard.tsx
@@ -29,9 +29,11 @@ type WizardState = 'drop' | 'previewing' | 'preview' | 'importing' | 'done';
 interface ImportWizardProps {
     accountId: number;
     onClose?: () => void;
+    /** Called from the "view transactions" button on the done screen, after `onClose`. */
+    onViewTransactions?: () => void;
 }
 
-export function ImportWizard({ accountId, onClose }: ImportWizardProps) {
+export function ImportWizard({ accountId, onClose, onViewTransactions }: ImportWizardProps) {
     const { t } = useTranslation();
     const queryClient = useQueryClient();
 
@@ -387,9 +389,11 @@ export function ImportWizard({ accountId, onClose }: ImportWizardProps) {
                     <p className="text-center text-sm text-muted-foreground">{importStatus?.progress ?? 0}%</p>
                 </div>
                 <p className="font-semibold">{t('bankImport.progress.processing')}</p>
-                {importStatus?.importedRows !== undefined && (
+                {/* totalRows defaults to 0 on the backend until parsing finishes, not undefined — checking it directly
+                    (rather than importedRows) avoids a meaningless "0 von 0" flash before the real count is known. */}
+                {!!importStatus?.totalRows && (
                     <p className="text-sm text-muted-foreground">
-                        {t('bankImport.progress.rows', { imported: importStatus.importedRows, total: importStatus.totalRows ?? '?' })}
+                        {t('bankImport.progress.rows', { imported: importStatus.importedRows ?? 0, total: importStatus.totalRows })}
                     </p>
                 )}
             </div>
@@ -437,7 +441,14 @@ export function ImportWizard({ accountId, onClose }: ImportWizardProps) {
                     </div>
                 )}
 
-                <Button onClick={() => onClose?.()}>{t('bankImport.result.viewTransactions')}</Button>
+                <Button
+                    onClick={() => {
+                        onClose?.();
+                        onViewTransactions?.();
+                    }}
+                >
+                    {t('bankImport.result.viewTransactions')}
+                </Button>
             </div>
         );
     }
@@ -451,9 +462,11 @@ interface ImportWizardDialogProps {
     accountId: number | null;
     open: boolean;
     onOpenChange: (open: boolean) => void;
+    /** Called with the imported account's id when the user clicks "view transactions" on the done screen. */
+    onViewTransactions?: (accountId: number) => void;
 }
 
-export function ImportWizardDialog({ accountId, open, onOpenChange }: ImportWizardDialogProps) {
+export function ImportWizardDialog({ accountId, open, onOpenChange, onViewTransactions }: ImportWizardDialogProps) {
     const { t } = useTranslation();
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
@@ -462,7 +475,13 @@ export function ImportWizardDialog({ accountId, open, onOpenChange }: ImportWiza
                     <DialogTitle>{t('bankImport.title')}</DialogTitle>
                     <p className="text-sm text-muted-foreground">{t('bankImport.wizard.dropSubtitle')}</p>
                 </DialogHeader>
-                {accountId != null && <ImportWizard accountId={accountId} onClose={() => onOpenChange(false)} />}
+                {accountId != null && (
+                    <ImportWizard
+                        accountId={accountId}
+                        onClose={() => onOpenChange(false)}
+                        onViewTransactions={() => onViewTransactions?.(accountId)}
+                    />
+                )}
             </DialogContent>
         </Dialog>
     );

--- a/frontend/spa/src/components/BankAccounts/ImportWizard.tsx
+++ b/frontend/spa/src/components/BankAccounts/ImportWizard.tsx
@@ -476,11 +476,7 @@ export function ImportWizardDialog({ accountId, open, onOpenChange, onViewTransa
                     <p className="text-sm text-muted-foreground">{t('bankImport.wizard.dropSubtitle')}</p>
                 </DialogHeader>
                 {accountId != null && (
-                    <ImportWizard
-                        accountId={accountId}
-                        onClose={() => onOpenChange(false)}
-                        onViewTransactions={() => onViewTransactions?.(accountId)}
-                    />
+                    <ImportWizard accountId={accountId} onClose={() => onOpenChange(false)} onViewTransactions={() => onViewTransactions?.(accountId)} />
                 )}
             </DialogContent>
         </Dialog>

--- a/frontend/spa/src/components/views/KontenView.tsx
+++ b/frontend/spa/src/components/views/KontenView.tsx
@@ -28,8 +28,8 @@ import { ImportWizardDialog } from '@/components/BankAccounts/ImportWizard';
 import { MatchDrawer } from '@/components/BankAccounts/MatchDrawer';
 import { LoadingState } from '@/components/common/LoadingState';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
-import { SortHeader } from '@/components/ui/SortHeader';
 import { BaseButton } from '@/components/ui/shadecn/BaseButton';
+import { SortHeader } from '@/components/ui/SortHeader';
 import { ReviewDrawer } from '@/components/views/BelegeView';
 import {
     useBankAccounts,

--- a/frontend/spa/src/components/views/KontenView.tsx
+++ b/frontend/spa/src/components/views/KontenView.tsx
@@ -28,8 +28,8 @@ import { ImportWizardDialog } from '@/components/BankAccounts/ImportWizard';
 import { MatchDrawer } from '@/components/BankAccounts/MatchDrawer';
 import { LoadingState } from '@/components/common/LoadingState';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
-import DropdownMenu from '@/components/ui/DropdownMenu';
 import { SortHeader } from '@/components/ui/SortHeader';
+import { BaseButton } from '@/components/ui/shadecn/BaseButton';
 import { ReviewDrawer } from '@/components/views/BelegeView';
 import {
     useBankAccounts,
@@ -65,10 +65,6 @@ function fmtDate(date: string | Date | undefined): string {
 
 // Soft elevation for the page's white surfaces — same two-layer shadow the Belege/Transaktionen cards use.
 const cardShadow = 'shadow-[0_1px_2px_rgba(20,20,40,.05),0_6px_22px_rgba(20,20,40,.05)]';
-
-// Tab-bar import action — sized to sit level with the segmented tab bar next to it.
-const importBtnCls =
-    'flex items-center gap-1.5 px-3.5 py-2 text-sm font-semibold rounded-xl bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-foreground hover:border-primary/40 hover:text-primary transition-colors whitespace-nowrap';
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
 
@@ -451,7 +447,7 @@ function AbgleichTab({ accounts, onOpenDrawer }: { accounts: BankAccountResponse
 
                     {/* Pagination */}
                     {totalPages > 1 && (
-                        <div className="flex items-center justify-between mt-4">
+                        <div className="flex items-center justify-between mt-4 mb-4">
                             <span className="text-xs text-muted-foreground">{t('konten.pagination.pageOf', { page: page + 1, total: totalPages })}</span>
                             <div className="flex items-center gap-1">
                                 <button
@@ -523,7 +519,15 @@ const PAGE_SIZE = 50;
 // action columns are fixed-width so the pills and buttons line up down the list regardless of row content.
 const ACCOUNT_TX_COLUMNS = '7.5rem minmax(0, 2fr) minmax(0, 1fr) 7.5rem 7.5rem';
 
-function AccountTab({ account, onOpenDrawer }: { account: BankAccountResponse; onOpenDrawer: (id: number) => void }) {
+function AccountTab({
+    account,
+    onOpenDrawer,
+    onImport,
+}: {
+    account: BankAccountResponse;
+    onOpenDrawer: (id: number) => void;
+    onImport: (accountId: number) => void;
+}) {
     const { t } = useTranslation();
     const [statusFilter, setStatusFilter] = usePersistedState<StatusFilter>('hopps.konten.account.statusFilter', 'ALL');
     const [page, setPage] = useState(0);
@@ -596,7 +600,15 @@ function AccountTab({ account, onOpenDrawer }: { account: BankAccountResponse; o
             </div>
 
             <div className="mb-4">
-                <BankTxFilterBar filters={filters} />
+                <BankTxFilterBar
+                    filters={filters}
+                    actions={
+                        <BaseButton size="sm" className="gap-1.5 whitespace-nowrap" onClick={() => onImport(account.id!)}>
+                            <Upload className="w-4 h-4" />
+                            {t('konten.import')}
+                        </BaseButton>
+                    }
+                />
             </div>
 
             {isLoading ? (
@@ -977,9 +989,6 @@ export function KontenView() {
     const totalOpen = Object.values(openCountByAccount).reduce((a, b) => a + b, 0);
 
     const activeAccount = accounts.find((a) => String(a.id) === tab);
-    // Which account an import from the tab bar lands in: the open account tab, or the only account there is.
-    // With several accounts and a non-account tab open it stays null and the button turns into a picker.
-    const importTargetId = activeAccount?.id ?? (accounts.length === 1 ? accounts[0].id! : null);
 
     const tabs: { id: TabId; label: string; badge?: number }[] = [
         { id: 'abgleich', label: t('konten.tabs.abgleich'), badge: totalOpen > 0 ? totalOpen : undefined },
@@ -1069,9 +1078,8 @@ export function KontenView() {
                 )}
             </div>
 
-            {/* Segmented tab bar + import action. The import button lives here rather than inside a single tab so it
-                stays reachable from every tab; the target account is the open account tab, or picked from a menu when
-                the current tab isn't account-specific and there is more than one account. */}
+            {/* Segmented tab bar. Import now lives next to the filter bar inside each account's own tab, where the
+                target account is always unambiguous — no cross-account picker needed. */}
             <div className="flex items-center justify-between gap-3 flex-wrap">
                 <div className="flex gap-0.5 rounded-xl bg-gray-100 dark:bg-gray-800 p-0.5 w-fit flex-wrap">
                     {tabs.map((t_) => (
@@ -1093,29 +1101,11 @@ export function KontenView() {
                         </button>
                     ))}
                 </div>
-
-                {importTargetId !== null ? (
-                    <button type="button" onClick={() => setImportAccountId(importTargetId)} className={importBtnCls}>
-                        <Upload className="w-4 h-4" />
-                        {t('konten.import')}
-                    </button>
-                ) : accounts.length > 0 ? (
-                    <DropdownMenu
-                        label={t('konten.imports.account')}
-                        items={accounts.map((a) => ({ title: a.name ?? '', onClick: () => setImportAccountId(a.id!) }))}
-                    >
-                        <button type="button" className={importBtnCls}>
-                            <Upload className="w-4 h-4" />
-                            {t('konten.import')}
-                            <ChevronDown className="w-4 h-4" />
-                        </button>
-                    </DropdownMenu>
-                ) : null}
             </div>
 
             {/* Tab content */}
             {tab === 'abgleich' && <AbgleichTab accounts={accounts} onOpenDrawer={openMatchDrawer} />}
-            {activeAccount && <AccountTab account={activeAccount} onOpenDrawer={openMatchDrawer} />}
+            {activeAccount && <AccountTab account={activeAccount} onOpenDrawer={openMatchDrawer} onImport={setImportAccountId} />}
             {tab === 'importe' && <ImporteTab accounts={accounts} />}
 
             {/* Match drawer */}
@@ -1150,6 +1140,7 @@ export function KontenView() {
                         refetch();
                     }
                 }}
+                onViewTransactions={(id) => setTab(String(id))}
             />
         </div>
     );


### PR DESCRIPTION
- Move the Importieren button into each account tab next to its filter bar, styled as primary
- Align the filter bar's search field and filter toggle to match the Transaktionen page's look
- Fix pagination bottom margin
- "Transaktionen anzeigen" after an import now jumps to the account it was imported into
Stop showing "0 von 0 Zeilen importiert" before the real count is known