### PR TITLE
chore(chart): bump hopps chart to 0.2.10 (unblock prod)

### DIFF
--- a/charts/hopps/Chart.yaml
+++ b/charts/hopps/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.9
+version: 0.2.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
## Warum

Die prod-`HelmRelease` in `hopps.cloud` pinnt bereits Chart `0.2.10`, aber dieser Tag wurde nie in die OCI-Registry publiziert. Flux-prod ist deshalb blockiert:

```
HelmChart 'hopps-prod/hopps-prod-hopps' is not ready: chart pull error:
ghcr.io/hopps-app/hopps/hopps:0.2.10: not found
```

(prod läuft noch auf dem letzten guten Release, aber es werden keine prod-Änderungen mehr ausgerollt.)

## Was

Bump der Chart-Version `0.2.9 → 0.2.10`. **Keine Template-Änderungen.** Der Merge triggert `helm-release.yaml`, publiziert den `0.2.10`-Tag, und Flux-prod kann den Chart wieder ziehen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)