### PR TITLE
Fix: chart and Bommel tree collapsing to zero height

### DIFF
--- a/frontend/spa/src/layouts/default/AuthLayout.tsx
+++ b/frontend/spa/src/layouts/default/AuthLayout.tsx
@@ -34,7 +34,7 @@ export default function AuthLayout() {
                     className={`flex-1 flex flex-col min-h-0 min-w-0 ml-0 transition-[margin] duration-300 ease-in-out ${collapsed ? 'sm:ml-16' : 'sm:ml-60'}`}
                 >
                     <main className="flex-1 min-h-0 overflow-auto">
-                        <div className="flex min-h-full flex-col">
+                        <div className="flex h-full flex-col">
                             <div className="flex-1 p-4 sm:p-7">
                                 <ErrorBoundary key={location.pathname}>
                                     <Outlet />


### PR DESCRIPTION
AuthLayout's content wrapper used min-h-full instead of h-full, introduced by the Impressum/Datenschutz footer change (
[#802](https://github.com/hopps-app/hopps/pull/802)
). Since min-height doesn't give a flex container a definite size up front, the flex-1 content area no longer stretched to fill the viewport