### PR TITLE
Fix/transaktionen filterbar UI

### DIFF
--- a/frontend/spa/src/components/views/TransactionenView.tsx
+++ b/frontend/spa/src/components/views/TransactionenView.tsx
@@ -838,12 +838,10 @@ function TransactionRow({
                 shrink at all — without both the long names overflowed and pushed the later columns out of line. */}
             {!hideBommel && (
                 <span className="min-w-0 pr-3">
-                    {tx.bommelName ? (
+                    {tx.bommelName && (
                         <span className="block truncate text-[13.5px] text-muted-foreground" title={tx.bommelName}>
                             {tx.bommelName}
                         </span>
-                    ) : (
-                        <Badge variant="warn">{t('transactions.unassigned')}</Badge>
                     )}
                 </span>
             )}
@@ -896,19 +894,8 @@ function TransactionRow({
                     if (Math.abs(total) < 0.005) return null;
                     const remaining = total - covered; // signed
                     const open = Math.abs(remaining);
-                    if (open > 0.005) {
-                        const positive = remaining > 0;
-                        const over = Math.abs(covered) > Math.abs(total) + 0.005;
-                        const label = over ? 'transactions.overCovered' : 'transactions.openToCover';
-                        return (
-                            <span
-                                className="text-[11px] font-semibold tabular-nums whitespace-nowrap"
-                                style={{ color: positive ? 'var(--positive)' : 'var(--negative)' }}
-                            >
-                                {t(label, { amount: `${positive ? '+' : '–'} ${fmtCurrency(open)}` })}
-                            </span>
-                        );
-                    }
+                    // "offen"/"überdeckt" indicator hidden for now.
+                    if (open > 0.005) return null;
                     // Fully covered: surface a positive status on drafts (still being reconciled); confirmed rows are
                     // done, so they stay clean.
                     if (tx.status === 'DRAFT') {
@@ -1253,12 +1240,12 @@ export function TransactionenView() {
                                 setPage(0);
                             }}
                             placeholder={t('transactions.filters.search')}
-                            className="w-full rounded-xl border border-border-soft bg-[var(--background-secondary)] py-[11px] pl-[38px] pr-3.5 text-[14.5px] text-foreground transition-shadow placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-[3px] focus:ring-[var(--accent-surface)]"
+                            className="h-10 w-full rounded-xl border border-border-soft bg-[var(--background-secondary)] pl-[38px] pr-3.5 text-[14.5px] text-foreground transition-shadow placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-[3px] focus:ring-[var(--accent-surface)]"
                         />
                     </div>
 
                     {/* Status segmented toggle */}
-                    <div className="inline-flex gap-0.5 p-1" style={{ background: 'var(--surface-track)', borderRadius: 12 }}>
+                    <div className="inline-flex h-10 items-center gap-0.5 p-1" style={{ background: 'var(--surface-track)', borderRadius: 12 }}>
                         {(['ALL', 'CONFIRMED', 'DRAFT'] as const).map((s) => {
                             const active = statusFilter === s;
                             const label = s === 'DRAFT' ? t('transactions.status.drafts') : t(`transactions.status.${s.toLowerCase()}`);
@@ -1269,7 +1256,7 @@ export function TransactionenView() {
                                         setStatusFilter(s);
                                         setPage(0);
                                     }}
-                                    className="inline-flex items-center gap-[7px] px-4 py-2 font-bold transition-colors"
+                                    className="inline-flex h-8 items-center gap-[7px] px-4 font-bold transition-colors"
                                     style={{
                                         fontSize: 13.5,
                                         borderRadius: 9,
@@ -1300,10 +1287,10 @@ export function TransactionenView() {
                     <button
                         onClick={() => setAdvancedOpen((v) => !v)}
                         aria-expanded={advancedOpen}
-                        className="inline-flex items-center gap-[7px] whitespace-nowrap font-semibold transition-colors"
+                        className="inline-flex h-10 items-center gap-[7px] whitespace-nowrap font-semibold transition-colors"
                         style={{
                             fontSize: 13.5,
-                            padding: '8px 14px',
+                            padding: '0 14px',
                             borderRadius: 9,
                             border: '1px solid',
                             borderColor: advancedOpen ? 'transparent' : 'var(--border-soft)',
@@ -1332,8 +1319,9 @@ export function TransactionenView() {
                     {hasFilters && (
                         <button
                             onClick={resetAll}
-                            className="text-[13px] font-semibold text-[var(--ink-faint)] hover:text-foreground transition-colors underline-offset-2 hover:underline"
+                            className="ml-auto inline-flex h-10 items-center gap-1.5 rounded-full border border-border-soft px-4 text-[14px] font-bold text-foreground transition-colors hover:bg-[var(--surface-sunken)]"
                         >
+                            <RotateCcw size={14} />
                             {t('transactions.filters.reset')}
                         </button>
                     )}

--- a/frontend/spa/src/layouts/default/AuthLayout.tsx
+++ b/frontend/spa/src/layouts/default/AuthLayout.tsx
@@ -34,7 +34,7 @@ export default function AuthLayout() {
                     className={`flex-1 flex flex-col min-h-0 min-w-0 ml-0 transition-[margin] duration-300 ease-in-out ${collapsed ? 'sm:ml-16' : 'sm:ml-60'}`}
                 >
                     <main className="flex-1 min-h-0 overflow-auto">
-                        <div className="flex min-h-full flex-col">
+                        <div className="flex h-full flex-col">
                             <div className="flex-1 p-4 sm:p-7">
                                 <ErrorBoundary key={location.pathname}>
                                     <Outlet />

--- a/frontend/spa/src/locales/de.json
+++ b/frontend/spa/src/locales/de.json
@@ -536,7 +536,7 @@
             "to": "Bis",
             "privatelyPaid": "Privat bezahlt",
             "detached": "Nicht verknüpft",
-            "reset": "Filter zurücksetzen",
+            "reset": "Zurücksetzen",
             "allCategories": "Alle Kategorien",
             "allBommels": "Alle Bommels",
             "allAreas": "Alle Sphären",

--- a/frontend/spa/src/locales/en.json
+++ b/frontend/spa/src/locales/en.json
@@ -537,7 +537,7 @@
             "to": "To",
             "privatelyPaid": "Privately paid",
             "detached": "Not linked",
-            "reset": "Reset filters",
+            "reset": "Reset",
             "allCategories": "All categories",
             "allBommels": "All bommels",
             "allAreas": "All areas",


### PR DESCRIPTION
### Summary

Small UI cleanup pass on the Transaktionen filter bar and table row, based on feedback that the filter bar looked misaligned and the row was showing confusing/noisy information.

- Search input, status toggle (Alle/Bestätigt/Entwürfe), and Filter button now share a consistent 40px height (h-10) instead of each deriving its own height from padding — they previously rendered at 46px/44px/38px respectively and didn't line up.
- The filter "Zurücksetzen" control is now a bordered pill button with a reset icon, right-aligned in the bar, matching the existing "Bearbeiten" button style — instead of a plain underlined text link. Also dropped the redundant "Filter" prefix from the label ("Filter zurücksetzen" → "Zurücksetzen" / "Reset filters" → "Reset").
- Hid the "offen: …" / "überdeckt: …" coverage-delta text under each row's amount for now.
- The Bommel column is now left blank instead of showing a "Nicht zugeordnet" warning badge when no Bommel is assigned (this only ever applies to drafts, since confirming a transaction already requires a Bommel).